### PR TITLE
updated requets version to something newer that contains the ssl fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
 ]
 
-requires = ["requests==1.2.3", ]
+requires = ["requests>=2.6.0", ]
 
 # This might not be the best idea.
 try:


### PR DESCRIPTION
There's an SSL error in the older version of requests that prevents pyspotlight from being installed..

Collecting requests==1.2.3 (from pyspotlight->xtas)
  Downloading requests-1.2.3.tar.gz (348kB)
    100% |████████████████████████████████| 358kB 3.5MB/s
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-zegFbq/requests/setup.py", line 6, in <module>
        import requests
      File "/tmp/pip-build-zegFbq/requests/requests/__init__.py", line 53, in <module>
        from requests.packages.urllib3.contrib import pyopenssl
      File "/tmp/pip-build-zegFbq/requests/requests/packages/urllib3/contrib/pyopenssl.py", line 42, in <module>
        ssl.PROTOCOL_SSLv3: OpenSSL.SSL.SSLv3_METHOD,
    AttributeError: 'module' object has no attribute 'PROTOCOL_SSLv3'

